### PR TITLE
40 axis labels

### DIFF
--- a/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
+++ b/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
@@ -4,7 +4,11 @@ import { scaleBand, scaleLinear } from '@visx/scale'
 import { Bar } from '@visx/shape'
 import { Group } from '@visx/group'
 import { useAsset } from '@context/Asset'
-import { AxisBottom, AxisLeft, AxisTop } from '@visx/axis'
+import { AxisBottom, AxisLeft, TicksRendererProps } from '@visx/axis'
+import Publisher, { PublisherProps } from '@shared/Publisher'
+import { Scale } from '@visx/brush/lib/types'
+import { accountTruncate } from '@utils/web3'
+import Link from 'next/link'
 
 const verticalMargin = 120
 
@@ -119,6 +123,28 @@ export default function IndividualUseVisualization({
           <AxisBottom
             top={285}
             scale={xScale}
+            tickFormat={(val: string) => accountTruncate(val)}
+            // tickComponent={(tickRendererProps: TicksRendererProps) => {
+            //   ;<Publisher account={accountTruncate(val)} />
+            // }}
+            // tickComponent={(val: string) => (
+            //   <div>
+            //     <Link href={`/profile/${accountTruncate(val)}`}>
+            //       <a title="Show profile page.">{accountTruncate(val)}</a>
+            //     </Link>
+            //   </div>
+            // )}
+            // ticksComponent={[...ids.keys()].map((d: string) => (
+            //   <Publisher key={`tick-${d}`} account={d} />
+            // ))}
+            // tickComponent={(props: TickRendererProps) => (
+            //   <Publisher account={props.x} />
+            // )}
+            // ticksComponent={(scale: TicksRendererProps<Scale>) => (
+            //   <Publisher
+            //     account={'0x05c02a63f7c04dB0c1a73e4B000b3A80f8613E56'}
+            //   />
+            // )}
             numTicks={20}
             stroke="#02346d"
             tickStroke="#02346d"

--- a/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
+++ b/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
@@ -81,8 +81,15 @@ export default function IndividualUseVisualization({
   return (
     <div>
       <svg width={width} height={height}>
-        <LinearGradient id="stroke" from="#58dfff" to="#ffffff" />
-        <rect fill="url('#stroke')" width="100%" height="100%" rx={14} />
+        <LinearGradient id="stroke" from="#e6faff" to="#ffffff" />
+        <rect
+          fill="url('#stroke')"
+          strokeWidth={1}
+          stroke="#e2e2e2"
+          width="100%"
+          height="100%"
+          rx={4}
+        />
         <Group top={verticalMargin / 2}>
           {[...ids.keys()].slice(0, maxBarAmount).map((d) => {
             const address = d

--- a/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
+++ b/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
@@ -4,17 +4,9 @@ import { scaleBand, scaleLinear } from '@visx/scale'
 import { Bar } from '@visx/shape'
 import { Group } from '@visx/group'
 import { useAsset } from '@context/Asset'
-import {
-  AxisBottom,
-  AxisLeft,
-  TickRendererProps,
-  TicksRendererProps
-} from '@visx/axis'
-import Publisher, { PublisherProps } from '@shared/Publisher'
-import { Scale } from '@visx/brush/lib/types'
+import { AxisBottom, AxisLeft } from '@visx/axis'
 import { accountTruncate } from '@utils/web3'
 import Link from 'next/link'
-import { Text } from '@visx/text'
 
 const verticalMargin = 120
 const maxBarAmount = 10

--- a/src/components/Asset/AssetContent/TransactionHistoryVisualization.tsx
+++ b/src/components/Asset/AssetContent/TransactionHistoryVisualization.tsx
@@ -158,8 +158,15 @@ export default withTooltip<TimelineProps, Order>(
     return (
       <div>
         <svg width={width} height={height}>
-          <LinearGradient id="stroke" from="#ff00a5" to="#999999" />
-          <rect fill="url('#stroke')" width="100%" height="100%" rx={14} />
+          <LinearGradient id="stroke" from="#e6faff" to="#ffffff" />
+          <rect
+            fill="url('#stroke')"
+            strokeWidth={1}
+            stroke="#e2e2e2"
+            width="100%"
+            height="100%"
+            rx={4}
+          />
           {initialOrders.map((order: Order, i) => {
             return (
               <Group top={height / 4} key={`filtered-dot-${i}`}>

--- a/src/components/Asset/AssetContent/index.tsx
+++ b/src/components/Asset/AssetContent/index.tsx
@@ -50,13 +50,11 @@ export default function AssetContent({
 
         <div className={styles.transactionHistory}>
           <h3>Transaction History Visualization</h3>
-          <div>
-            <TransactionHistoryVisualization
-              width={1125}
-              height={400}
-              events={true}
-            />
-          </div>
+          <TransactionHistoryVisualization
+            width={1125}
+            height={400}
+            events={true}
+          />
         </div>
 
         <div>


### PR DESCRIPTION
Resized, bolded, and centered axis titles.

Truncated the account addresses at each tick label to only show first 4 and last 4 digits (e.g. 0xbeef...feed).

Made the account addresses at each tick label a clickable link that brings the user to the address's profile page. 

Limited the maximum number of columns to 10 so that users are not overwhelmed with data. 
