### PR TITLE
New assets will have default blue NFT image icon

### DIFF
--- a/src/@utils/SvgWaves.ts
+++ b/src/@utils/SvgWaves.ts
@@ -27,7 +27,8 @@ class Point {
 enum WaveColors {
   Violet = '#e000cf',
   Pink = '#ff4092',
-  Grey = '#8b98a9'
+  Grey = '#8b98a9',
+  Blue = '#0fb9fc'
 }
 
 export class SvgWaves {
@@ -55,7 +56,7 @@ export class SvgWaves {
       width: 99,
       height: 99,
       viewBox: '0 0 99 99',
-      color: WaveColors.Pink,
+      color: WaveColors.Blue,
       fill: true,
       layerCount: 4,
       pointsPerLayer: randomIntFromInterval(3, 4),


### PR DESCRIPTION
Tried changing the pink waves icon used for people's default NFT image. Later realized that these images are generated when the asset is published/first created, and it is not a style of the page. 

This change does not change existing asset's colors on the NFT image, but it does modify the publish page so that all new assets/datatokens have a default blue image wave-generated image. 

May want to consider creating our own datatoken/NFT on the Mumbai testnet, and use that for demos for color consistency