### PR TITLE
Changed brush window border to black

### DIFF
--- a/src/components/Asset/AssetContent/TransactionHistoryVisualization.tsx
+++ b/src/components/Asset/AssetContent/TransactionHistoryVisualization.tsx
@@ -213,7 +213,7 @@ export default withTooltip<TimelineProps, Order>(
               onClick={() => setFilteredOrders(orders)}
               selectedBoxStyle={{
                 fill: `url(#${'brush_pattern'})`,
-                stroke: 'white'
+                stroke: 'black'
               }}
               useWindowMoveEvents
               renderBrushHandle={(props) => <BrushHandle {...props} />}


### PR DESCRIPTION
Changed the border for the brush window to black so that there was a greater contrast with the background when selecting a portion of transactions to view. 
Close #51.